### PR TITLE
Adding extern C guards to messagebox header file

### DIFF
--- a/messagebox.h
+++ b/messagebox.h
@@ -1,6 +1,10 @@
 #ifndef MESSAGEBOX_X11_MESSAGEBOX_H
 #define MESSAGEBOX_X11_MESSAGEBOX_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <X11/Xlib.h>
 
 typedef struct Button{
@@ -10,4 +14,8 @@ typedef struct Button{
 
 int Messagebox(const char* title, const wchar_t* text, const Button* buttons, int numButtons);
 
+#ifdef __cplusplus
+}
+#endif
+    
 #endif //MESSAGEBOX_X11_MESSAGEBOX_H


### PR DESCRIPTION
First, I want to thank you for providing a great X11 message box code snippet.
I think this tiny C library could be very useful for C++ developers as well.

So I suggest adding the use of `extern "C"` to tell the C++ compiler/linker to use the C naming and calling conventions.
It will enable using your main repository as a submodule as a third-party dependency in a C++ project and properly cite your project.

I would like to thank you again for your time and consideration.